### PR TITLE
API Resource Classes + Metafields Refactor

### DIFF
--- a/src/events/ShopifyProductSyncEvent.php
+++ b/src/events/ShopifyProductSyncEvent.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\shopify\events;
+
+use craft\events\CancelableEvent;
+use craft\shopify\elements\Product as ProductElement;
+use Shopify\Rest\Admin2022_10\Product as ShopifyProduct;
+
+/**
+ * Event triggered just before a synchronized product element is going to be saved.
+ *
+ * @author Pixel & Tonic, Inc. <support@pixelandtonic.com>
+ */
+class ShopifyProductSyncEvent extends CancelableEvent
+{
+    /**
+     * @var ProductElement Craft product element being synchronized.
+     */
+    public ProductElement $element;
+
+    /**
+     * @var ShopifyProduct Source Shopify API resource.
+     */
+    public ShopifyProduct $source;
+
+    /**
+     * @var array List of Shopify metafields for the product.
+     */
+    public array $metafields;
+}

--- a/src/handlers/Product.php
+++ b/src/handlers/Product.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
 
 namespace craft\shopify\handlers;
 
@@ -13,7 +18,7 @@ class Product implements Handler
         switch ($topic) {
             case Topics::PRODUCTS_UPDATE:
             case Topics::PRODUCTS_CREATE:
-                Plugin::getInstance()->getProducts()->createOrUpdateProduct($body);
+                Plugin::getInstance()->getProducts()->syncProductByShopifyId($body['id']);
                 break;
             case Topics::PRODUCTS_DELETE:
                 Plugin::getInstance()->getProducts()->deleteProductByShopifyId($body['id']);

--- a/src/helpers/Metafields.php
+++ b/src/helpers/Metafields.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @link https://craftcms.com/
+ * @copyright Copyright (c) Pixel & Tonic, Inc.
+ * @license https://craftcms.github.io/license/
+ */
+
+namespace craft\shopify\helpers;
+
+use craft\helpers\Json;
+use Shopify\Rest\Admin2022_10\Metafield as ShopifyMetafield;
+
+class Metafields
+{
+    /**
+     * @var array Data types that should be expanded into an array.
+     * @see https://shopify.dev/apps/metafields/types
+     */
+    public const JSON_TYPES = [
+        'dimension',
+        'json',
+        'money',
+        'rating',
+        'volume',
+    ];
+
+    /**
+     * @var string Prefix given to metafield types that are configured to accept multiple values and will be encoded as JSON.
+     * @see https://shopify.dev/apps/metafields/types#list-types
+     */
+    public const LIST_PREFIX = 'list';
+
+    /**
+     * Unpacks metadata from the Shopify API.
+     * 
+     * @param ShopifyMetafield[] $fields
+     * @return array
+     */
+    public static function unpack(array $fields): array
+    {
+        $data = [];
+
+        foreach ($fields as $field) {
+            $data[$field->key] = static::decode($field);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Turn a metafield API resource into a simple value, based on its type.
+     */
+    public static function decode(ShopifyMetafield $field)
+    {
+        $value = $field->value;
+
+        if (in_array($field->type, static::JSON_TYPES) || strpos($field->type, static::LIST_PREFIX) === 0) {
+            $value = Json::decodeIfJson($value);
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
This meandering PR accomplishes a few things, most of which I had no intention of touching but ended up making sense as I hacked around:
- Refactors `Shopify\Client\Rest` and “Session” initialization;
- Fetches products iteratively/recursively, according to the Shopify [pagination docs](https://shopify.dev/api/usage/pagination-rest) (no more 250-product limit!) (`craft\shopify\services\Api::getAll()`);
- Uses the native Shopify API resource classes (`Shopify\Rest\Base` subclasses) to fetch and pass data throughout sync methods;
- Massages JSON-packed metafields and indexes them by key before storage (`craft\shopify\helpers\Metafields`);
- Emits a (cancelable) event just before a product element is saved, including the source Shopify product object, the target element, and the metafields;

All I _really_ wanted to try out was the last item, here—which provides a hook for developers to act on synchronization and/or perform other actions in Craft based on the incoming data.

For example:

```php
use craft\shopify\events\ShopifyProductSyncEvent;
use craft\shopify\services\Products;
use yii\base\Event;

Event::on(
    Products::class,
    Products::EVENT_BEFORE_SYNCHRONIZE_PRODUCT,
    function(ShopifyProductSyncEvent $event) {
        // Cancel the sync if a flag is set via a Shopify metafield:
        if ($event->metafields['do_not_sync'] ?? false) {
            $event->isValid = false;
        }
    }
);
```

Ultimately, I think the most important change is probably the switch from raw `GET` requests to using the active-query-esque resource classes, i.e. `Shopify\Rest\Admin2022_10\Product::all()`. If anything it feels a bit more resilient—letting them deal with normalizing responses, rather than trying to unzip whatever awful data structure comes back.