### PR TITLE
Buy SDK Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,8 +399,14 @@ A simple URL generator is available via `craft.shopify.store`. You may have noti
   text: 'Add to Cart',
   target: '_blank',
 }) }}
+```
 
-{# Link to a product page #}
+The same params argument can be passed to a product element’s `getShopifyUrl()` method:
+
+```twig
+{% for variant in product.variants %}
+  <a href="{{ product.getShopifyUrl({ id: variant.id }) }}">{{ variant.title }}</a>
+{% endfor %}
 ```
 
 ## Product Field

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Cart management and checkout are not currently supported in a native way.
 However, Shopify maintains the [Javascript Buy SDK](https://shopify.dev/custom-storefronts/tools/js-buy) as a means of interacting with their [Storefront API](https://shopify.dev/api/storefront) to create completely custom shopping experiences.
 
 > **Note**  
-> Use of the Storefront API requires a different [access key](https://help.shopify.com/en/manual/apps/custom-apps#update-storefront-api-access-scopes-for-a-custom-app), and assumes that you have published your products into the Storefront app’s “sales channel.”
+> Use of the Storefront API requires a different [access key](https://help.shopify.com/en/manual/apps/custom-apps#update-storefront-api-access-scopes-for-a-custom-app), and assumes that you have published your products into the Storefront app’s [sales channel](https://shopify.dev/custom-storefronts/tools/js-buy#step-2-make-your-products-and-collections-available).
 
 The plugin makes no assumptions about how you use your product data in the front-end, but provides the tools necessary to connect it with the SDK. As an example, let’s look at how you might render a list of products in Twig, and hook up a custom client-side cart…
 
@@ -442,13 +442,11 @@ client.checkout.create().then((checkout) => {
 
 ### Buy Button JS
 
-The above example can be simplified with the [Buy Button JS](https://shopify.dev/custom-storefronts/tools/buy-button), but the principles are the same:
+The above example can be simplified with the [Buy Button JS](https://shopify.dev/custom-storefronts/tools/buy-button), which provides some ready-made UI components, like a fully-featured cart. The principles are the same:
 
 1. Make products available via the appropriate sales channels in Shopify;
 2. Output synchronized product data in your front-end;
 3. Initialize, attach, or trigger SDK functionality in response to events, using Shopify-specific identifiers from step #2;
-
-_Buy Button JS_ provides some ready-made UI components, like a fully-featured cart.
 
 ### Checkout
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <h1 align="center">Shopify for Craft CMS</h1>
 
-Connect your [Craft CMS](https://craftcms.com/) site to a [Shopify](https://shopify.com) store and keep your products in sync.
+Build a content-driven storefront by synchronizing [Shopify](https://shopify.com) products into [Craft CMS](https://craftcms.com/).
 
 ## Topics
 

--- a/README.md
+++ b/README.md
@@ -435,10 +435,10 @@ For each legacy Shopify Product field in your project, do the following:
 
 Run the following command (substituting appropriate values) for each place you added the field in step #2, above:
 
-    - `resave/entries` &rarr; The [re-save command](https://craftcms.com/docs/4.x/console-commands.html#resave) for the element type the field layout is attached to;
-    - `mySectionHandle` &rarr; A stand-in for any criteria that need to be applied to the element type you’re re-saving;
-    - `oldShopifyField` &rarr; Field handle from the old version of the plugin (used inside the `--to` argument closure);
-    - `newShopifyField` &rarr; New field handle created in step #1, above;
+- `resave/entries` &rarr; The [re-save command](https://craftcms.com/docs/4.x/console-commands.html#resave) for the element type the field layout is attached to;
+- `mySectionHandle` &rarr; A stand-in for any criteria that need to be applied to the element type you’re re-saving;
+- `oldShopifyField` &rarr; Field handle from the old version of the plugin (used inside the `--to` argument closure);
+- `newShopifyField` &rarr; New field handle created in step #1, above;
 
     ```bash
     php craft resave/entries \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 Connect your [Craft CMS](https://craftcms.com/) site to a [Shopify](https://shopify.com) store and keep your products in sync.
 
+## Topics
+
+- :package: [Installation](#installation): Set up the plugin and get connected to Shopify.
+- :card_file_box: [Working with Products](#product-element): Learn what kind of data is available and how to access it.
+- :bookmark_tabs: [Templating](#templating): Tips and tricks for using products in Twig.
+- :leaves: [Upgrading](#migrating-from-v2x): Take advantage of new features and performance improvements.
+- :telescope: [Advanced Features](#going-further): Go further with your integration.
+
 ## Installation
 
 The Shopify plugin requires Craft CMS 4.0.0 or later.

--- a/README.md
+++ b/README.md
@@ -511,17 +511,17 @@ use craft\shopify\services\Products;
 use yii\base\Event;
 
 Event::on(
-    Products::class,
-    Products::EVENT_BEFORE_SYNCHRONIZE_PRODUCT,
-    function(ShopifyProductSyncEvent $event) {
-        // Example 1: Cancel the sync if a flag is set via a Shopify metafield:
-        if ($event->metafields['do_not_sync'] ?? false) {
-            $event->isValid = false;
-        }
-
-        // Example 2: Set a field value from metafield data:
-        $event->element->setFieldValue('myNumberFieldHandle', $event->metafields['cool_factor']);
+  Products::class,
+  Products::EVENT_BEFORE_SYNCHRONIZE_PRODUCT,
+  function(ShopifyProductSyncEvent $event) {
+    // Example 1: Cancel the sync if a flag is set via a Shopify metafield:
+    if ($event->metafields['do_not_sync'] ?? false) {
+      $event->isValid = false;
     }
+
+    // Example 2: Set a field value from metafield data:
+    $event->element->setFieldValue('myNumberFieldHandle', $event->metafields['cool_factor']);
+  }
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -444,10 +444,17 @@ client.checkout.create().then((checkout) => {
 
 The above example can be simplified with the [Buy Button JS](https://shopify.dev/custom-storefronts/tools/buy-button), but the principles are the same:
 
-1. Make products available in the appropriate sales channels;
+1. Make products available via the appropriate sales channels in Shopify;
 2. Output synchronized product data in your front-end;
-3. Initialize or attach library functionality in response to events;
-4. 
+3. Initialize, attach, or trigger SDK functionality in response to events, using Shopify-specific identifiers from step #2;
+
+_Buy Button JS_ provides some ready-made UI components, like a fully-featured cart.
+
+### Checkout
+
+While solutions exist for creating a customized shopping experience, _checkout will always happen on Shopify’s platform_. This is not a technical limitation so much as it is a policy—Shopify’s checkout flow is fast, reliable, secure, and familiar to many shoppers.
+
+If you want your customers’ entire journey to be kept on-site, we encourage you to try out our powerful ecommerce plugin, [Commerce](https://craftcms.com/commerce).
 
 ### Helpers
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ However, Shopify maintains the [Javascript Buy SDK](https://shopify.dev/custom-s
 
 > **Note**  
 > Use of the Storefront API requires a different [access key](https://help.shopify.com/en/manual/apps/custom-apps#update-storefront-api-access-scopes-for-a-custom-app), and assumes that you have published your products into the Storefront app’s [sales channel](https://shopify.dev/custom-storefronts/tools/js-buy#step-2-make-your-products-and-collections-available).
+> 
+> Your public Storefront API token can be stored with your other credentials in `.env` and output in your front-end with the `{{ getenv('...') }}` Twig helper—or just baked into a Javascript bundle. **Keep your other secrets safe!** This is the only one that can be disclosed.
 
 The plugin makes no assumptions about how you use your product data in the front-end, but provides the tools necessary to connect it with the SDK. As an example, let’s look at how you might render a list of products in Twig, and hook up a custom client-side cart…
 

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ Run the following command (substituting appropriate values) for each place you a
     php craft resave/entries \
       --section=mySectionHandle \
       --set=newShopifyField \
-      --to="fn(\$entry) => collect(json_decode(\$entry->oldShopifyField))->map(fn (\$item) => \craft\shopify\Plugin::getInstance()->getProducts()->getProductIdByShopifyId(\$item))->unique()->all()"
+      --to="fn(\$entry) => collect(json_decode(\$entry->oldShopifyField))->map(fn (\$id) => \craft\shopify\Plugin::getInstance()->getProducts()->getProductIdByShopifyId(\$id))->unique()->all()"
     ```
 
 ### Updating Templates

--- a/src/web/twig/CraftVariableBehavior.php
+++ b/src/web/twig/CraftVariableBehavior.php
@@ -30,7 +30,6 @@ class CraftVariableBehavior extends Behavior
     {
         parent::init();
 
-        // Point `craft.commerce` to the craft\commerce\Plugin instance
         $this->shopify = Plugin::getInstance();
     }
 


### PR DESCRIPTION
Primarily concerned with getting some [Buy SDK](https://shopify.dev/custom-storefronts/tools/js-buy) and [Buy Button JS](https://shopify.dev/custom-storefronts/tools/buy-button) examples into the Readme, but includes a number of other improvements.