### PR TITLE
Fixed return value for actionSaveSettings

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -50,9 +50,9 @@ class SettingsController extends Controller
     /**
      * Save the settings.
      *
-     * @return YiiResponse
+     * @return YiiResponse|null
      */
-    public function actionSaveSettings(): YiiResponse
+    public function actionSaveSettings(): ?YiiResponse
     {
         $settings = Craft::$app->getRequest()->getParam('settings');
         $plugin = Craft::$app->getPlugins()->getPlugin('shopify');


### PR DESCRIPTION
**Description**
saving API Connection tab without filling inputs throws an error
`craft\shopify\controllers\SettingsController::actionSaveSettings(): Return value must be of type yii\web\Response, null returned`

this PR adds null to accepted return values.