### PR TITLE
Store the product field layout in the project config

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -15,10 +15,13 @@ use craft\base\Model;
 use craft\base\Plugin as BasePlugin;
 use craft\console\Controller;
 use craft\console\controllers\ResaveController;
+use craft\events\ConfigEvent;
 use craft\events\DefineConsoleActionsEvent;
 use craft\events\RegisterComponentTypesEvent;
 use craft\events\RegisterUrlRulesEvent;
+use craft\helpers\ProjectConfig as ProjectConfigHelper;
 use craft\helpers\UrlHelper;
+use craft\models\FieldLayout;
 use craft\services\Elements;
 use craft\services\Fields;
 use craft\services\Utilities;
@@ -51,10 +54,12 @@ use yii\base\InvalidConfigException;
  */
 class Plugin extends BasePlugin
 {
+    public const PC_PATH_PRODUCT_FIELD_LAYOUTS = 'shopify.productFieldLayout';
+
     /**
      * @var string
      */
-    public string $schemaVersion = '4.0.4'; // For some reason the 2.2+ version of the plugin was at 4.0 schema version
+    public string $schemaVersion = '4.0.5'; // For some reason the 2.2+ version of the plugin was at 4.0 schema version
 
     /**
      * @inheritdoc
@@ -116,6 +121,29 @@ class Plugin extends BasePlugin
                 $this->_registerSiteRoutes();
             }
         }
+
+        Craft::$app->getProjectConfig()->onUpdate(self::PC_PATH_PRODUCT_FIELD_LAYOUTS, function(ConfigEvent $event) {
+            $data = $event->newValue;
+            $fieldsService = Craft::$app->getFields();
+
+            if (empty($data) || empty($config = reset($data))) {
+                $fieldsService->deleteLayoutsByType(Product::class);
+                return;
+            }
+
+            // Make sure fields are processed
+            ProjectConfigHelper::ensureAllFieldsProcessed();
+
+            // Save the field layout
+            $layout = FieldLayout::createFromConfig($config);
+            $layout->id = $fieldsService->getLayoutByType(Product::class)->id;
+            $layout->type = Product::class;
+            $layout->uid = key($data);
+            $fieldsService->saveLayout($layout, false);
+
+            // Invalidate product caches
+            Craft::$app->getElements()->invalidateCachesForElementType(Product::class);
+        });
 
         // Globally register shopify webhooks registry event handlers
         Registry::addHandler(Topics::PRODUCTS_CREATE, new ProductHandler());

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -8,6 +8,7 @@
 namespace craft\shopify\controllers;
 
 use Craft;
+use craft\helpers\StringHelper;
 use craft\queue\jobs\ResaveElements;
 use craft\shopify\elements\Product;
 use craft\shopify\models\Settings;
@@ -70,11 +71,15 @@ class SettingsController extends Controller
 
         $fieldLayout = Craft::$app->getFields()->assembleLayoutFromPost();
         $fieldLayout->type = Product::class;
-        $fieldLayoutSaved = Craft::$app->fields->saveLayout($fieldLayout);
+
+        $projectConfig = Craft::$app->getProjectConfig();
+        $uid = StringHelper::UUID();
+        $fieldLayoutConfig = $fieldLayout->getConfig();
+        $projectConfig->set(Plugin::PC_PATH_PRODUCT_FIELD_LAYOUTS, [$uid => $fieldLayoutConfig], 'Save the Shopify product field layout');
 
         $pluginSettings->setProductFieldLayout($fieldLayout);
 
-        if (!$settingsSuccess || !$fieldLayoutSaved) {
+        if (!$settingsSuccess) {
             return $this->asModelFailure(
                 $pluginSettings,
                 Craft::t('shopify', 'Couldn’t save settings.'),

--- a/src/migrations/m221215_010047_store_field_layout_in_project_config.php
+++ b/src/migrations/m221215_010047_store_field_layout_in_project_config.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace craft\shopify\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\helpers\StringHelper;
+use craft\shopify\Plugin;
+
+/**
+ * m221215_010047_store_field_layout_in_project_config migration.
+ */
+class m221215_010047_store_field_layout_in_project_config extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        // Don't make the same config changes twice
+        $projectConfig = Craft::$app->getProjectConfig();
+        $schemaVersion = $projectConfig->get('plugins.shopify.schemaVersion', true);
+
+        if (version_compare($schemaVersion, '4.0.5', '<')) {
+            $fieldLayout = Plugin::getInstance()->getSettings()->getProductFieldLayout();
+
+            $muteEvents = $projectConfig->muteEvents;
+            $projectConfig->muteEvents = true;
+            $uid = StringHelper::UUID();
+            $fieldLayoutConfig = $fieldLayout->getConfig();
+            $projectConfig->set(Plugin::PC_PATH_PRODUCT_FIELD_LAYOUTS, [$uid => $fieldLayoutConfig], 'Save the Shopify product field layout');
+            $projectConfig->muteEvents = $muteEvents;
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m221215_010047_store_field_layout_in_project_config cannot be reverted.\n";
+        return false;
+    }
+}


### PR DESCRIPTION
### Description

Adjusts the product field layout to be stored in the project config.

### Related issues

- craftcms/cms#12459