### PR TITLE
Add metadata API request to queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fixed a SQL error that occurred when syncing products with a large number of tags assigned in Shopify. ([#54](https://github.com/craftcms/shopify/issues/54))
-- Product metadata is now synced over the queue.
+- Product metadata is now synced over the queue to avoid the Shopify API rate limiting.
 
 ## 3.1.0 - 2022-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Fixed a SQL error that occurred when syncing products with a large number of tags assigned in Shopify. ([#54](https://github.com/craftcms/shopify/issues/54))
 - Product metadata is now synced over the queue.
-- 
+
 ## 3.1.0 - 2022-12-14
 
 - Added the `resave/shopify-products` console command. ([#47](https://github.com/craftcms/shopify/issues/47))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 - Fixed a SQL error that occurred when syncing products with a large number of tags assigned in Shopify. ([#54](https://github.com/craftcms/shopify/issues/54))
-
+- Product metadata is now synced over the queue.
+- 
 ## 3.1.0 - 2022-12-14
 
 - Added the `resave/shopify-products` console command. ([#47](https://github.com/craftcms/shopify/issues/47))

--- a/src/jobs/UpdateProductMetadata.php
+++ b/src/jobs/UpdateProductMetadata.php
@@ -17,7 +17,7 @@ class UpdateProductMetadata extends BaseJob
     /**
      * @inheritdoc
      */
-    function execute($queue): void
+    public function execute($queue): void
     {
         $api = Plugin::getInstance()->getApi();
         $product = Product::find()->shopifyId($this->shopifyProductId)->one();

--- a/src/jobs/UpdateProductMetadata.php
+++ b/src/jobs/UpdateProductMetadata.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace craft\shopify\jobs;
+
+use Craft;
+use craft\queue\BaseJob;
+use craft\shopify\elements\Product;
+use craft\shopify\Plugin;
+
+/**
+ * Updates the metadata for a Shopify product.
+ */
+class UpdateProductMetadata extends BaseJob
+{
+    public string $shopifyProductId;
+
+    /**
+     * @inheritdoc
+     */
+    function execute($queue): void
+    {
+        $api = Plugin::getInstance()->getApi();
+        $product = Product::find()->shopifyId($this->shopifyProductId)->one();
+        if ($product) {
+            $metaFields = $api->getMetafieldsByProductId($this->shopifyProductId);
+            $product->setMetafields($metaFields);
+            Craft::$app->elements->saveElement($product);
+            sleep(1); // Avoid rate limiting
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultDescription(): ?string
+    {
+        return null;
+    }
+}

--- a/src/jobs/UpdateProductMetadata.php
+++ b/src/jobs/UpdateProductMetadata.php
@@ -12,7 +12,7 @@ use craft\shopify\Plugin;
  */
 class UpdateProductMetadata extends BaseJob
 {
-    public string $shopifyProductId;
+    public int $shopifyProductId;
 
     /**
      * @inheritdoc

--- a/src/services/Products.php
+++ b/src/services/Products.php
@@ -5,7 +5,6 @@ namespace craft\shopify\services;
 use Craft;
 use craft\base\Component;
 use craft\helpers\ArrayHelper;
-use craft\queue\Queue;
 use craft\shopify\elements\Product as ProductElement;
 use craft\shopify\events\ShopifyProductSyncEvent;
 use craft\shopify\helpers\Metafields as MetafieldsHelper;

--- a/src/services/Products.php
+++ b/src/services/Products.php
@@ -5,9 +5,11 @@ namespace craft\shopify\services;
 use Craft;
 use craft\base\Component;
 use craft\helpers\ArrayHelper;
+use craft\queue\Queue;
 use craft\shopify\elements\Product as ProductElement;
 use craft\shopify\events\ShopifyProductSyncEvent;
 use craft\shopify\helpers\Metafields as MetafieldsHelper;
+use craft\shopify\jobs\UpdateProductMetadata;
 use craft\shopify\Plugin;
 use craft\shopify\records\ProductData as ProductDataRecord;
 use Shopify\Rest\Admin2022_10\Metafield as ShopifyMetafield;
@@ -59,8 +61,13 @@ class Products extends Component
         $products = $api->getAllProducts();
 
         foreach ($products as $product) {
-            $metafields = $api->getMetafieldsByProductId($product->id);
-            $this->createOrUpdateProduct($product, $metafields);
+            $this->createOrUpdateProduct($product);
+            Craft::$app->getQueue()->push(new UpdateProductMetadata([
+                'description' => Craft::t('shopify', 'Updating product metadata for “{title}”', [
+                    'title' => $product->title,
+                ]),
+                'shopifyProductId' => $product->id,
+            ]));
         }
 
         // Remove any products that are no longer in Shopify just in case.


### PR DESCRIPTION
### Description

API limits are being hit while doing a sync of all products. Since metadata can not be requested in bulk, this PR moves metadata API syncing to the queue with a job that includes a 1-second sleep.

