### PR TITLE
Ignore template variable is headless is enabled

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -64,7 +64,9 @@ class SettingsController extends Controller
 
         // Remove from editable table namespace
         $settings['uriFormat'] = $settings['routing']['uriFormat'];
-        $settings['template'] = $settings['routing']['template'];
+        if (!Craft::$app->getConfig()->getGeneral()->headlessMode) {
+            $settings['template'] = $settings['routing']['template'];
+        }
         unset($settings['routing']);
 
         $settingsSuccess = Craft::$app->getPlugins()->savePluginSettings($plugin, $settings);


### PR DESCRIPTION
### Description
When headless mode was enabled the "template" is undefined.


### Related issues
Upon saving plugin settings and error is shown preventing the save.
