### PR TITLE
Fix querying shopifyId with array of ids

### DIFF
--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -219,7 +219,7 @@ class ProductQuery extends ElementQuery
         ]);
 
         if (isset($this->shopifyId)) {
-            $this->subQuery->andWhere(['shopify_productdata.shopifyId' => $this->shopifyId]);
+            $this->subQuery->andWhere(Db::parseParam('shopify_productdata.shopifyId', $this->shopifyId));
         }
 
         if (isset($this->productType)) {


### PR DESCRIPTION
### Description

Fixes Craft product elements not being deleted when they are deleted in Shopify. 

### Related issues

