### PR TITLE
Mass sync async flag

### DIFF
--- a/src/console/controllers/SyncController.php
+++ b/src/console/controllers/SyncController.php
@@ -20,11 +20,32 @@ use yii\console\ExitCode;
  */
 class SyncController extends Controller
 {
+    /** @var string $defaultAction */
     public $defaultAction = 'products';
 
+    /**
+     * @var bool Whether to sync product and other associated data in the queue.
+     * @since 3.3.0
+     */
+    public bool $async = true;
+
+    /**
+     * @inheritdoc
+     */
+    public function options($actionID): array
+    {
+        $options = parent::options($actionID);
+        $options[] = 'async';
+        return $options;
+    }
+
+    /**
+     * Sync all Shopify data.
+     */
     public function actionAll()
     {
         $this->_syncProducts();
+        return ExitCode::OK;
     }
 
     /**
@@ -39,7 +60,7 @@ class SyncController extends Controller
     private function _syncProducts(): void
     {
         $this->stdout('Syncing Shopify products…' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
-        Plugin::getInstance()->getProducts()->syncAllProducts();
+        Plugin::getInstance()->getProducts()->syncAllProducts($this->async);
         $this->stdout('Finished' . PHP_EOL . PHP_EOL, Console::FG_GREEN);
     }
 }

--- a/src/controllers/ProductsController.php
+++ b/src/controllers/ProductsController.php
@@ -45,8 +45,10 @@ class ProductsController extends \craft\web\Controller
      */
     public function actionSync(): Response
     {
-        Plugin::getInstance()->getProducts()->syncAllProducts();
-        return $this->asSuccess(Craft::t('shopify','Products successfully synced'));
+        $async = (bool)Craft::$app->getRequest()->getParam('async', false);
+
+        Plugin::getInstance()->getProducts()->syncAllProducts($async);
+        return $this->asSuccess(Craft::t('shopify', 'Products successfully synced'));
     }
 
     /**

--- a/src/elements/db/ProductQuery.php
+++ b/src/elements/db/ProductQuery.php
@@ -223,13 +223,13 @@ class ProductQuery extends ElementQuery
         }
 
         if (isset($this->productType)) {
-            $this->subQuery->andWhere(Db::parseParam(['shopify_productdata.productType' => $this->productType]));
+            $this->subQuery->andWhere(Db::parseParam('shopify_productdata.productType', $this->productType));
         }
 
         if (isset($this->publishedScope)) {
-            $this->subQuery->andWhere(Db::parseParam(['shopify_productdata.publishedScope' => $this->publishedScope]));
+            $this->subQuery->andWhere(Db::parseParam('shopify_productdata.publishedScope', $this->publishedScope));
         }
-        
+
         if (isset($this->shopifyStatus)) {
             $this->subQuery->andWhere(Db::parseParam('shopify_productdata.shopifyStatus', $this->shopifyStatus));
         }

--- a/src/services/Products.php
+++ b/src/services/Products.php
@@ -15,7 +15,6 @@ use craft\shopify\helpers\Metafields as MetafieldsHelper;
 use craft\shopify\jobs\UpdateProductMetadata;
 use craft\shopify\Plugin;
 use craft\shopify\records\ProductData as ProductDataRecord;
-use Shopify\Rest\Admin2022_01\Metafield;
 use Shopify\Rest\Admin2022_10\Metafield as ShopifyMetafield;
 use Shopify\Rest\Admin2022_10\Product as ShopifyProduct;
 
@@ -74,7 +73,6 @@ class Products extends Component
                     'shopifyProductId' => $product->id,
                 ]));
             } else {
-                /** @var Metafield $metaFields */
                 $metaFields = $api->getMetafieldsByProductId($product->id);
                 $this->createOrUpdateProduct($product, $metaFields);
             }

--- a/src/templates/utilities/_sync.twig
+++ b/src/templates/utilities/_sync.twig
@@ -1,7 +1,19 @@
 <h2>{{ "Shopify Sync"|t('shopify') }}</h2>
+{% import "_includes/forms" as forms %}
+
 <form method="POST">
     {{ actionInput('') }}
     {{ csrfInput() }}
+
+    {{ forms.lightswitchField({
+        label: "Use queue for syncing related objects like meta fields."|t('shopify'),
+        warning: 'If disabled timeouts may occur, or API rate limits may be hit.'|t('commerce'),
+        id: 'async',
+        name: 'async',
+        value: 1,
+        on: true
+    }) }}
+
     <a class="btn submit formsubmit" data-icon="refresh"
        data-action="shopify/products/sync"
        data-confirm="{{ 'Are you sure you want run a complete sync of all products?'|t('shopify') }}">


### PR DESCRIPTION
### Description

Allows an async flag to run the sync without a queue of the metafields saved after the product saves

`php craft shopify/sync/all --async=0`

also added to the utility:

<img width="924" alt="CleanShot 2023-09-22 at 15 24 51@2x" src="https://github.com/craftcms/shopify/assets/133571/afda021d-6026-4df3-b3c7-7cf6b70949bc">


Syncing of one product does synchronous syncing, but when mass syncing we put additional things like metafields into the queue. 