### PR TITLE
Added preliminary support for ShopifyVariant metafields

### DIFF
--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -107,7 +107,26 @@ class Api extends Component
     }
 
     /**
-     * Retrieves "metafields" for the provided Shopify product ID.
+     * Retrieves "metafields" for the provided Shopify variant ID.
+     *
+     * @param int $id Shopify Variant ID
+     * @return ShopifyMetafield[]
+     */
+    public function getMetafieldsByVariantId(int $id): array
+    {
+        /** @var ShopifyMetafield[] $metafields */
+        $metafields = $this->getAll(ShopifyMetafield::class, [
+            'metafield' => [
+                'owner_id' => $id,
+                'owner_resource' => 'variant',
+            ],
+        ]);
+
+        return $metafields;
+    }
+
+    /**
+     * Retrieves "variants" for the provided Shopify product ID.
      *
      * @param int $id Shopify Product ID
      */
@@ -180,8 +199,7 @@ class Api extends Component
     {
         $pluginSettings = Plugin::getInstance()->getSettings();
 
-        if (
-            $this->_session === null &&
+        if ($this->_session === null &&
             ($apiKey = App::parseEnv($pluginSettings->apiKey)) &&
             ($apiSecretKey = App::parseEnv($pluginSettings->apiSecretKey))
         ) {


### PR DESCRIPTION
### Description

Fixes #99 by adding a new method to query Metafields on Variant items.

It's not the best implementation but works, no support for MetaObjects, since the REST API won't expose them.


### Related issues

#99 

