### PR TITLE
Added the ability to sync variant meta fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release Notes for Shopify
 
+## Unreleased
+
+- Added support for syncing variant meta fields. ([#99](https://github.com/craftcms/shopify/issues/99))
+- Added the `syncProductMetafields` and `syncVariantMetafields` config settings, which can be enabled to sync meta fields.
+- Added `craft\shopify\models\Settings::$syncProductMetafields`.
+- Added `craft\shopify\models\Settings::$syncVariantMetafields`.
+
 ## 4.0.0 - 2023-11-02
 
 > [!IMPORTANT]

--- a/README.md
+++ b/README.md
@@ -125,12 +125,7 @@ php craft shopify/sync/products
 
 Going forward, your products will be automatically kept in sync via [webhooks](#set-up-webhooks).
 
-The following settings available for controlling the product synchronization process:
-
-| Setting                 | Type   | Default | Description |
-|-------------------------|--------|---------|-------------|
-| `syncProductMetafields` | `bool` | `true`  | Whether product metafields should be included when syncing products. This adds an extra API request per product.            |
-| `syncVariantMetafields` | `bool` | `false` | Whether variant metafields should be included when syncing products. This adds an extra API request per variant. |
+The [`syncProductMetafields` and `syncVariantMetafields` settings](#settings) govern what data is synchronized via this process.
 
 > [!NOTE]
 > Smaller stores with only a few products can perform synchronization via the **Shopify Sync** utility.
@@ -791,6 +786,16 @@ There is no need to query the Shopify API to render product details in your temp
 ```
 
 ## Going Further
+
+### Settings
+
+The following settings can be controlled by creating a `shopify.php` file in your `config/` directory.
+
+| Setting                 | Type   | Default | Description |
+|-------------------------|--------|---------|-------------|
+| `syncProductMetafields` | `bool` | `true`  | Whether product metafields should be included when syncing products. This adds an extra API request per product. |
+| `syncVariantMetafields` | `bool` | `false` | Whether variant metafields should be included when syncing products. This adds an extra API request per variant. |
+
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -733,7 +733,7 @@ It’s safe to remove the old plugin package (`nmaier95/shopify-product-fetcher`
 
 For each legacy Shopify Product field in your project, do the following:
 
-1. Create a _new_ [Shopify Products](#product-field) field, giving it a a new handle and name;
+1. Create a _new_ [Shopify Products](#product-field) field, giving it a new handle and name;
 2. Add the field to any layouts where the legacy field appeared;
 
 ### Re-saving Data

--- a/README.md
+++ b/README.md
@@ -791,9 +791,17 @@ The following settings can be controlled by creating a `shopify.php` file in you
 
 | Setting                 | Type   | Default | Description |
 |-------------------------|--------|---------|-------------|
-| `syncProductMetafields` | `bool` | `true`  | Whether product metafields should be included when syncing products. This adds an extra API request per product. |
+| `apiKey` | `string` | — | Shopify API key. |
+| `apiSecretKey` | `string` | — | Shopify API secret key. |
+| `accessToken` | `string` | — | Shopify API access token. |
+| `hostName` | `string` | — | Shopify [host name](#store-hostname) |
+| `uriFormat` | `string` | — | Product element URI format. |
+| `template` | `string` | — | Product element template path. |
+| `syncProductMetafields` | `bool` | `true` | Whether product metafields should be included when syncing products. This adds an extra API request per product. |
 | `syncVariantMetafields` | `bool` | `false` | Whether variant metafields should be included when syncing products. This adds an extra API request per variant. |
 
+> [!NOTE]
+> Setting `apiKey`, `apiSecretKey`, `accessToken`, and `hostName` via `shopify.php` will override Project Config values set via the control panel during [app setup](#create-a-shopify-app).
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -117,16 +117,23 @@ Products from your Shopify store are represented in Craft as product [elements](
 
 ### Synchronization
 
-Once the plugin has been configured, you can perform an initial synchronization of all products via the **Shopify Sync** utility.
+Once the plugin has been configured, you can perform an initial synchronization of all products via the command line.
 
-> [!NOTE]
-> Larger stores with 100+ products should perform the initial synchronization via the command line instead:
->
-> ```sh
-> php craft shopify/sync/products
-> ```
+```sh
+php craft shopify/sync/products
+```
 
 Going forward, your products will be automatically kept in sync via [webhooks](#set-up-webhooks).
+
+The following settings available for controlling the product synchronization process:
+
+| Setting                 | Type   | Default | Description |
+|-------------------------|--------|---------|-------------|
+| `syncProductMetafields` | `bool` | `true`  | Whether product metafields should be included when syncing products. This adds an extra API request per product.            |
+| `syncVariantMetafields` | `bool` | `false` | Whether variant metafields should be included when syncing products. This adds an extra API request per variant. |
+
+> [!NOTE]
+> Smaller stores with only a few products can perform synchronization via the **Shopify Sync** utility.
 
 ### Native Attributes
 
@@ -426,7 +433,8 @@ You can get an array of variant objects for a product by calling [`product.getVa
 
 Unlike products, variants in Craft…
 
-- …are represented exactly as [the API](https://shopify.dev/api/admin-rest/2023-10/resources/product-variant#resource-object) returns them;
+- …are represented as [the API](https://shopify.dev/api/admin-rest/2023-10/resources/product-variant#resource-object) returns them;
+- …the `metafields` property is accessible in addition to the API’s returned properties;
 - …use Shopify’s convention of underscores in property names instead of exposing [camel-cased equivalents](#native-attributes);
 - …are plain associative arrays;
 - …have no methods of their own;
@@ -441,6 +449,8 @@ Once you have a reference to a variant, you can output its properties:
 
 > **Note**  
 > The built-in [`currency`](https://craftcms.com/docs/4.x/dev/filters.html#currency) Twig filter is a great way to format money values.
+> 
+> The `metafields` property will only be populated if the `syncVariantMetafields` setting is enabled.
 
 ### Using Options
 

--- a/README.md
+++ b/README.md
@@ -794,14 +794,14 @@ The following settings can be controlled by creating a `shopify.php` file in you
 | `apiKey` | `string` | — | Shopify API key. |
 | `apiSecretKey` | `string` | — | Shopify API secret key. |
 | `accessToken` | `string` | — | Shopify API access token. |
-| `hostName` | `string` | — | Shopify [host name](#store-hostname) |
+| `hostName` | `string` | — | Shopify [host name](#store-hostname). |
 | `uriFormat` | `string` | — | Product element URI format. |
 | `template` | `string` | — | Product element template path. |
 | `syncProductMetafields` | `bool` | `true` | Whether product metafields should be included when syncing products. This adds an extra API request per product. |
 | `syncVariantMetafields` | `bool` | `false` | Whether variant metafields should be included when syncing products. This adds an extra API request per variant. |
 
 > [!NOTE]
-> Setting `apiKey`, `apiSecretKey`, `accessToken`, and `hostName` via `shopify.php` will override Project Config values set via the control panel during [app setup](#create-a-shopify-app).
+> Setting `apiKey`, `apiSecretKey`, `accessToken`, and `hostName` via `shopify.php` will override Project Config values set via the control panel during [app setup](#create-a-shopify-app). You can still reference environment values from the config file with `craft\helpers\App::env()`.
 
 ### Events
 

--- a/README.md
+++ b/README.md
@@ -123,9 +123,7 @@ Once the plugin has been configured, you can perform an initial synchronization 
 php craft shopify/sync/products
 ```
 
-The [`syncProductMetafields` and `syncVariantMetafields` settings](#settings) govern what data is synchronized via this process.
-
-Going forward, your products will be automatically kept in sync via [webhooks](#set-up-webhooks).
+The [`syncProductMetafields` and `syncVariantMetafields` settings](#settings) govern what data is synchronized via this process. Going forward, your products will be automatically kept in sync via [webhooks](#set-up-webhooks).
 
 > [!NOTE]
 > Smaller stores with only a few products can perform synchronization via the **Shopify Sync** utility.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,7 +56,7 @@ class Plugin extends BasePlugin
     /**
      * @var string
      */
-    public string $schemaVersion = '4.0.6'; // For some reason the 2.2+ version of the plugin was at 4.0 schema version
+    public string $schemaVersion = '4.0.7';
 
     /**
      * @inheritdoc

--- a/src/jobs/UpdateProductMetadata.php
+++ b/src/jobs/UpdateProductMetadata.php
@@ -11,6 +11,7 @@ use craft\shopify\records\ProductData as ProductDataRecord;
 /**
  * Updates the metadata for a Shopify product.
  *
+ * @TODO remove in next major version
  * @deprecated 4.0.0 No longer used internally due to the use of `Retry-After` headers in the Shopify API.
  */
 class UpdateProductMetadata extends BaseJob

--- a/src/migrations/m240402_105857_add_metafields_property_to_variants.php
+++ b/src/migrations/m240402_105857_add_metafields_property_to_variants.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace craft\shopify\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Query;
+use craft\shopify\records\ProductData;
+
+/**
+ * m240402_105857_add_metafields_property_to_variants migration.
+ */
+class m240402_105857_add_metafields_property_to_variants extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp(): bool
+    {
+        $productRows = (new Query())
+            ->select(['shopifyId', 'variants'])
+            ->from('{{%shopify_productdata}}')
+            ->all();
+
+        foreach ($productRows as $product) {
+            $variants = json_decode($product['variants'], true);
+            foreach ($variants as &$variant) {
+                if (isset($variant['metafields'])) {
+                    continue;
+                }
+
+                $variant['metafields'] = [];
+            }
+
+            $this->update('{{%shopify_productdata}}', ['variants' => json_encode($variants)], ['shopifyId' => $product['shopifyId']]);
+        }
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown(): bool
+    {
+        echo "m240402_105857_add_metafields_property_to_variants cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/migrations/m240402_105857_add_metafields_property_to_variants.php
+++ b/src/migrations/m240402_105857_add_metafields_property_to_variants.php
@@ -2,10 +2,8 @@
 
 namespace craft\shopify\migrations;
 
-use Craft;
 use craft\db\Migration;
 use craft\db\Query;
-use craft\shopify\records\ProductData;
 
 /**
  * m240402_105857_add_metafields_property_to_variants migration.

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -28,6 +28,22 @@ class Settings extends Model
     public string $template = '';
     private mixed $_productFieldLayout;
 
+    /**
+     * Whether product metafields should be included when syncing products. This adds an extra API request per product.
+     *
+     * @var bool
+     * @since 4.1.0
+     */
+    public bool $syncProductMetafields = true;
+
+    /**
+     * Whether variant metafields should be included when syncing products. This adds an extra API request per variant.
+     *
+     * @var bool
+     * @since 4.1.0
+     */
+    public bool $syncVariantMetafields = false;
+
     public function rules(): array
     {
         return [

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -95,12 +95,41 @@ class Api extends Component
      */
     public function getMetafieldsByProductId(int $id): array
     {
+        if (!Plugin::getInstance()->getSettings()->syncProductMetafields) {
+            return [];
+        }
+
+        return $this->getMetafieldsByIdAndOwnerResource($id, 'product');
+    }
+
+    /**
+     * @param int $id
+     * @return ShopifyMetafield[]
+     * @since 4.1.0
+     */
+    public function getMetafieldsByVariantId(int $id): array
+    {
+        if (!Plugin::getInstance()->getSettings()->syncVariantMetafields) {
+            return [];
+        }
+
+        return $this->getMetafieldsByIdAndOwnerResource($id, 'variants');
+    }
+
+    /**
+     * @param int $id
+     * @param string $ownerResource
+     * @return ShopifyMetafield[]
+     * @since 4.1.0
+     */
+    public function getMetafieldsByIdAndOwnerResource(int $id, string $ownerResource): array
+    {
         /** @var ShopifyMetafield[] $metafields */
         $metafields = $this->getAll(ShopifyMetafield::class, [
             'metafield' => [
                 'owner_id' => $id,
-                'owner_resource' => 'product',
-            ],
+                'owner_resource' => $ownerResource,
+            ]
         ]);
 
         return $metafields;

--- a/src/services/Api.php
+++ b/src/services/Api.php
@@ -129,7 +129,7 @@ class Api extends Component
             'metafield' => [
                 'owner_id' => $id,
                 'owner_resource' => $ownerResource,
-            ]
+            ],
         ]);
 
         return $metafields;


### PR DESCRIPTION
### Description
This PR introduces the ability to sync variant meta fields as well as settings around controlling what meta fields are sync'd into Craft.

The two new settings are:

- `syncProductMetafields` this is `true` by default
- `syncVariantMetafields`, this is `false` by default as it adds an extra API call for each variant in a product.

You can override these config settings in your project's `shopify.php` config file.

### Related issues
#99 
