### PR TITLE
Fixed API rate limiting when syncing meta fields and unpacking variant metafields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - v4
       - develop
       - main
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release Notes for Shopify
 
+## Unreleased
+
+- Fixed a bug where syncing meta fields would cause Shopify API rate limiting.
+- Fixed a bug where variant meta fields weren’t being unpacked.
+
 ## 5.1.0 - 2024-04-03
 
 - Added support for syncing variant meta fields. ([#99](https://github.com/craftcms/shopify/issues/99))


### PR DESCRIPTION
### Description
Shopify API SDK automatically deals with rate limiting, however it appears it it only through certain specific functions.

